### PR TITLE
Update Elixir and OTP versions (1.16+)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: 1.14
-              otp: 25.3
+              elixir: 1.16
+              otp: 26
             lint: lint
     steps:
       - uses: actions/checkout@v2

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule BroadwaySqs.MixProject do
     [
       app: :broadway_sqs,
       version: @version,
-      elixir: "~> 1.7",
+      elixir: "~> 1.16",
       name: "BroadwaySQS",
       description: @description,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
update min elixir to 1.16. This helps future PRs CI checks to pass